### PR TITLE
pip commands not required

### DIFF
--- a/UseCases/GLM_Fraud_Detection_InDB/GLM_Fraud_Detection_InDB.ipynb
+++ b/UseCases/GLM_Fraud_Detection_InDB/GLM_Fraud_Detection_InDB.ipynb
@@ -41,34 +41,6 @@
    "metadata": {},
    "source": [
     "<hr>\n",
-    "<p style = 'font-size:18px;font-family:Arial;color:#E37C4D'><b>Installing some dependencies</b>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%capture\n",
-    "# '%%capture' suppresses the display of installation steps of the following packages\n",
-    "!pip install --upgrade teradataml"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<p style = 'font-size:16px;font-family:Arial'>\n",
-    "    <i><b>*BEFORE proceeding, please RESTART the kernel to bring new software into Jupyter.</b></i>\n",
-    "</p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<hr>\n",
     "<b style = 'font-size:28px;font-family:Arial;color:#E37C4D'>1. Configuring the Environment</b>\n",
     "<p style = 'font-size:16px;font-family:Arial'>Here, we import the required libraries, set environment variables and environment paths (if required).</p>"
    ]


### PR DESCRIPTION
@DougEbel Please review the GLM_InDB usecase. Removed the pip commands. The notebook only contained one pip command to upgrade teradataml. As teradataml is already upgraded in the new machines, this command was not required. Thanks.