### PR TITLE
PR review changes - removed section 3.1.8

### DIFF
--- a/UseCases/Marketing_Campaign_Effectiveness/Marketing_Campaign_Effectiveness_Preditction_PY_SQL.ipynb
+++ b/UseCases/Marketing_Campaign_Effectiveness/Marketing_Campaign_Effectiveness_Preditction_PY_SQL.ipynb
@@ -672,52 +672,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ba50ebb-27f2-495f-89a9-d83b4fcd8f30",
-   "metadata": {},
-   "source": [
-    "<p style = 'font-size:18px;font-family:Arial;color:#E37C4D'><b>3.1.8 Analyse how earlier interactions with customers affected their decision to make a purchase.</b></p>    \n",
-    "<p style = 'font-size:16px;font-family:Arial'>Examining how clients behave when they contact you through different channels.</p>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1a8eb66b-bf27-4d83-979d-83ef585dc964",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig=px.line(df.loc[(df[\"prev_contacts_performed\"] < 11) & (df[\"purchased\"] == 'yes')].groupby(['prev_contacts_performed','purchased'], as_index=False)['age'].count().rename(columns={'age':'Count'}),\n",
-    "            x='prev_contacts_performed',y='Count',\n",
-    "            color='purchased',\n",
-    "            template='plotly_dark',\n",
-    "            color_discrete_sequence=['#4c72b0'])\n",
-    "\n",
-    "fig.update_layout(\n",
-    "                  title_text='<b style=\"font-family: Calibri (Body);\">Impact of Previous Campaign on Purchase<b><br>'\n",
-    "                  '<b style=\"font-family: Calibri (Body); font-size:0.7vw\">total amount of contacts performed </b>',\n",
-    "                  xaxis = dict(tickmode = 'linear',tick0 = 1,dtick = 1), \n",
-    "                  xaxis_title=\"Contacts performed\",\n",
-    "                  yaxis_title=\"Total purchase counts\",)\n",
-    "\n",
-    "fig.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e4bf4421-95cf-47f2-810f-14b1898396ae",
-   "metadata": {},
-   "source": [
-    "<p style = 'font-size:16px;font-family:Arial'>The graph shows a clear pattern: the likelihood of a customer making a purchase decreases as the number of interactions made before this campaign and for this client increases.</p>\n",
-    "\n",
-    "<p style = 'font-size:16px;font-family:Arial'>If multiple campaigns and multiple contacts are performed for the clients, there is a greater chance for the client to not be interested in purchasing the product. <b>At least 2 or 3 contacts</b> can be preferred to perform for the clients.</p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "6b15977b-f046-4a24-9637-5e897fe80119",
    "metadata": {},
    "source": [
-    "<p style = 'font-size:18px;font-family:Arial;color:#E37C4D'><b>3.1.9 Examine the impact of the most recent contact month on purchasing patterns</b></p>    \n",
+    "<p style = 'font-size:18px;font-family:Arial;color:#E37C4D'><b>3.1.8 Examine the impact of the most recent contact month on purchasing patterns</b></p>    \n",
     "<p style = 'font-size:16px;font-family:Arial'>Analysis of how the client's purchasing decision was impacted by the last contact month..</p>"
    ]
   },


### PR DESCRIPTION
@DougEbel - As par your suggestion, I have removed section 3.1.8. Please review it and merge to main.

* Suggested comment: https://github.com/Teradata/jupyter-demos/pull/315#pullrequestreview-1503129762

     * In 3.1.8, I still have a problem with graph and your conclusion: "If multiple campaigns and multiple contacts are performed for the clients, there is a greater chance for the client to not be interested in purchasing the product. At least 2 or 3 contacts can be preferred to perform for the clients. Looks to me like if the number of prior contacts was 0, you get the most purchases and that the yield even after 1 prior contact isn't worth it.

   * That is not a show stopper but if that part of the analysis doesn't produce explainable results, drop it since you've lots of other great stuff.