### PR TITLE
Update Generative_Question_Answering_Python.ipynb

### DIFF
--- a/UseCases/Generative_Question_Answering_GenAI/Generative_Question_Answering_Python.ipynb
+++ b/UseCases/Generative_Question_Answering_GenAI/Generative_Question_Answering_Python.ipynb
@@ -446,7 +446,7 @@
     "os.environ[\"OPENAI_API_KEY\"] = api_key\n",
     "\n",
     "# call open AI model - api\n",
-    "llm = OpenAI(temperature=0)"
+    "llm = OpenAI(temperature=0, model="gpt-3.5-turbo-instruct")"
    ]
   },
   {


### PR DESCRIPTION
Must define the Open AI model otherwise it will default to using 'text-davinci-003' which has been deprecated resulting in an error.  I recommend using model="gpt-3.5-turbo-instruct" as it has had the best results when I tested.