### PR TITLE
removed pandas and updated docs links

### DIFF
--- a/UseCases/Generative_Question_Answering_GenAI/Generative_Question_Answering_Python.ipynb
+++ b/UseCases/Generative_Question_Answering_GenAI/Generative_Question_Answering_Python.ipynb
@@ -172,8 +172,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import getpass\n",
+    "\n",
     "# enter your openai api key\n",
-    "api_key = input(prompt=\"\\n Please Enter OpenAI API key: \")"
+    "api_key = getpass.getpass(prompt=\"\\n Please Enter OpenAI API key: \")"
    ]
   },
   {
@@ -305,7 +307,6 @@
    "outputs": [],
    "source": [
     "tdf = DataFrame(in_schema(\"DEMO_MarketingCamp\", \"Retail_Marketing\"))\n",
-    "df = tdf.to_pandas()\n",
     "print(\"Data information: \\n\", tdf.shape)\n",
     "tdf.sort(\"customer_id\")"
    ]
@@ -398,19 +399,13 @@
     "from IPython.display import display, Markdown\n",
     "\n",
     "\n",
-    "\n",
     "def response_template(query, response):\n",
     "    if \"result\" in response:\n",
-    "\n",
     "        return f\"<p style = 'font-size:16px;font-family:Arial;color:#00233C'>SQL and response from user query {query}  <br> <b>{response['result']}<b>\"\n",
     "    else:\n",
-    "\n",
     "        return f\"<p style = 'font-size:16px;font-family:Arial;color:#00233C'>SQL and response from user query {query}  <br> <b>{response}<b>\"\n",
     "\n",
-    "\n",
-    "\n",
     "def error_template():\n",
-    "\n",
     "    return f\"<p style = 'font-size:16px;font-family:Arial;color:#00233C'>Sorry, there was an error while generating the SQL query. The GenAI may have made a mistake in the syntax of the query.  <br>\""
    ]
   },
@@ -661,7 +656,7 @@
     "    <li>Which profession has the most married people in Phoenix?</li>\n",
     "    <li>What is the month with the lowest sales?</li>\n",
     "    <li>What is the month with the highest number of marketing engagements?</li>\n",
-    "    <li>What is the number of purchases made by customers who are in management professions?</li>\n",
+    "    <li>What is the payment method distribution?</li>\n",
     "    <li>What is the average number of days between a customer's last contact and their next purchase?</li>\n",
     "    <li>What is the relationship between marital status and purchase frequency?</li>\n",
     "    <li>What is the most effective communication method for reaching customers who have not purchased from our company in the past 6 months?</li>\n",
@@ -759,8 +754,8 @@
     "\n",
     "<p style = 'font-size:16px;font-family:Arial;color:#00233c'><b>Links:</b></p>\n",
     "<ul style = 'font-size:16px;font-family:Arial;color:#00233C'>\n",
-    "    <li>Teradataml Python reference: <a href = 'https://docs.teradata.com/search/all?query=Python+Package+User+Guide&content-lang=en-US'>here</a></li>\n",
-    "    <li>Langchain Python reference: <a href='https://python.langchain.com/docs/get_started/introduction.html'>here</a></li>\n",
+    "    <li>Teradataml Python reference: <a href = 'https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/Teradata-Package-for-Python-User-Guide-17.20'>here</a></li>\n",
+    "    <li>Langchain Python reference: <a href='https://python.langchain.com/docs/get_started/introduction/'>here</a></li>\n",
     "</ul>"
    ]
   },


### PR DESCRIPTION
Hi @DallasBowden 

Please review this PR# https://github.com/Teradata/jupyter-demos/issues/581

----------------------------

**Reviewer 1 comments:**

- section 3.1 converts tdml df to pandas df just to print in sorted order.
- Link section to teradataml points to older teradataml version on docs.teradata
-Output of all cells is missing.



**Reviewer 1 suggestions:**
- In section 3.1, no need to convert to pandas df. directly use sort() method of teradataml df
- Update the links from older doc to new one: https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/Teradata-Package-for-Python-User-Guide-17.20
- Recompile notebook to verify generated SQL queries.



**Reviewer 2 comments:**
- use of to_pandas() should be avoided.
- Fix the link to latest teradataml guide


**Reviewer 2 suggestions:**
- use of to_pandas() should be avoided.
- Fix the link to latest teradataml guide