### PR TITLE
bug fix telco 5g

### DIFF
--- a/UseCases/Telco_5G_QOE_Analysis/Telco_5G_QOE_Analysis_SQL.ipynb
+++ b/UseCases/Telco_5G_QOE_Analysis/Telco_5G_QOE_Analysis_SQL.ipynb
@@ -2105,7 +2105,7 @@
    "source": [
     "CREATE VOLATILE TABLE TD_Glm_FeatureSelection AS(\n",
     "SELECT * FROM TD_GLM (\n",
-    "ON CLM_ADS_TRANSFORMED\n",
+    "ON CLM_ADS_TRANSFORMED AS InputTable\n",
     "USING\n",
     "InputColumns('Level','Qual','SNR','CQI','LTERSSI','DL_bitrate','UL_bitrate','Altitude','Height','Quality','NetworkTech','NetworkMode','Experiment_Type')\n",
     "ResponseColumn('rate_category')\n",


### PR DESCRIPTION
in TD_GLM As InputTable clause was made compulsary earlier it was optional, hence the sql was failing.  No other chanegs done