### PR TITLE
Used oreplace instead of replace to fix the notebook

### DIFF
--- a/UseCases/Energy_Consumption_Forecasting_AzureML/Energy_Consumption_Forecasting_AzureML.ipynb
+++ b/UseCases/Energy_Consumption_Forecasting_AzureML/Energy_Consumption_Forecasting_AzureML.ipynb
@@ -1123,7 +1123,7 @@
    "outputs": [],
    "source": [
     "out_df = out_df.assign(consumption_time = out_df.consumption_time.cast(type_=TIMESTAMP(6)))\n",
-    "out_df = out_df.assign(prediction = out_df.variable_out.replace(\"[\",\"\").replace(\"]\",\"\"))\n",
+    "out_df = out_df.assign(prediction = out_df.variable_out.oreplace(\"[\",\"\").oreplace(\"]\",\"\"))\n",
     "out_df = out_df.assign(prediction = out_df.prediction.cast(type_=FLOAT()))\n",
     "out_df = out_df.drop('variable_out', axis = 1)\n",
     "\n",


### PR DESCRIPTION
Notebook fails due to replace function which earlier worked. The fix has been incorporated. Using oreplace instead of replace.