### PR TITLE
Update 12_ModelOps_Model_Factory_REST_Python.ipynb

### DIFF
--- a/ModelOps/12_ModelOps_Model_Factory_REST_Python.ipynb
+++ b/ModelOps/12_ModelOps_Model_Factory_REST_Python.ipynb
@@ -187,7 +187,7 @@
    "outputs": [],
    "source": [
     "# base domain for ModelOps\n",
-    "url = \"https://\" + hostname + \":8443/modelops\"\n",
+    "url = \"https://\" + hostname + \"/modelops\"\n",
     "print(url)"
    ]
   },


### PR DESCRIPTION
updating link for url since last change of the clearscape URL (removing port 8443)