### PR TITLE
New Recipe notebook for BreushPaganGodfrey

### DIFF
--- a/Recipes/ClearScape_Functions/BreuschPaganGodfrey.ipynb
+++ b/Recipes/ClearScape_Functions/BreuschPaganGodfrey.ipynb
@@ -1,0 +1,383 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc549e6c-0cc4-4188-94a3-a9bdd3ae3dfa",
+   "metadata": {},
+   "source": [
+    "<header>\n",
+    "   <p  style='font-size:36px;font-family:Arial; color:#F0F0F0; background-color: #00233c; padding-left: 20pt; padding-top: 20pt;padding-bottom: 10pt; padding-right: 20pt;'>\n",
+    "       BreuschPaganGodfrey Function in Vantage\n",
+    "  <br>\n",
+    "       <img id=\"teradata-logo\" src=\"https://storage.googleapis.com/clearscape_analytics_demo_data/DEMO_Logo/teradata.svg\" alt=\"Teradata\" style=\"width: 125px; height: auto; margin-top: 20pt;\">\n",
+    "    </p>\n",
+    "</header>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ae7611a-0795-4168-b716-01fee6880cbd",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:20px;font-family:Arial'><b>Introduction</b></p>\n",
+    "<p style = 'font-size:18px;font-family:Arial'><b>BreuschPaganGodfrey</b></p>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>The BreuschPaganGodfrey() function is used to detect the presence of heteroscedasticity in regression analysis. Heteroscedasticity is the situation where the variability of the error term, such as the difference between the observed values and the predicted values, is not constant across all levels of the independent variables.</p>\n",
+    "\n",
+    "<p style = 'font-size:16px;font-family:Arial'>If heteroscedasticity is present in the data, an ordinary least squares (OLS) estimator can still provide unbiased estimates of the regression coefficients but it can lead to inefficient estimates. This causes the estimated standard errors of the coefficients to be biased and can underestimate the true standard errors. As a result, the hypothesis tests may be unreliable and lead to incorrect conclusions about the significance of the coefficients.</p>\n",
+    "\n",
+    "<p style = 'font-size:16px;font-family:Arial'> While heteroscedasticity can lead to biased and inefficient estimates, it may not be a major concern for OLS. For example, the following variations in the error variance may not be a concern:</p>\n",
+    "<li style = 'font-size:16px;font-family:Arial'>Small variations so the OLS estimator is unbiased and efficient.</li>\n",
+    "<li style = 'font-size:16px;font-family:Arial'>Sample sizes are large so that the OLS estimator is robust to heteroscedasticity.</li>\n",
+    "<li style = 'font-size:16px;font-family:Arial'>Estimates are not used for inference but for prediction.</li>\n",
+    "</p>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>BreuschPaganGodfrey involves regressing the squared residuals from the original regression on the independent variables and their squares, and then using the resulting regression to test whether the coefficients on the squared residuals are statistically different from zero.\n",
+    "BreuschPaganGodfrey is used in econometrics and other fields for regression analysis. It is used in conjunction with other diagnostic tests to assess the assumptions and validity of a regression model.</p>\n",
+    "\n",
+    "<p style = 'font-size:16px;font-family:Arial'>The following procedure is an example of how to use BreuschPaganGodfrey() function:</p>\n",
+    "<li style = 'font-size:16px;font-family:Arial'>Use MultivarRegr() to create regression model and generate residuals.</li>\n",
+    "<li style = 'font-size:16px;font-family:Arial'>Use BreuschPaganGodfrey() on the output DataFrame from MultivarRegr().</li>\n",
+    "</p>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b3a00b4-6661-4c91-9b2d-cb7b0b403140",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:2px;border:none;\">\n",
+    "<b style = 'font-size:20px;font-family:Arial'>1. Initiate a connection to Vantage</b>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2346857f-e0d3-488a-8a3f-ac6dff752c2b",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:16px;font-family:Arial'>In the section, we import the required libraries and set environment variables and environment paths (if required)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5af5af3-29d5-4f6a-8334-9df6924e7787",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from teradataml import (\n",
+    "    create_context,\n",
+    "    execute_sql,\n",
+    "    load_example_data,\n",
+    "    DataFrame, \n",
+    "    in_schema,\n",
+    "    TDSeries,\n",
+    "    MultivarRegr,\n",
+    "    BreuschPaganGodfrey,\n",
+    "    db_drop_table,\n",
+    "    db_drop_view,\n",
+    "    remove_context\n",
+    "    )\n",
+    "\n",
+    "# Modify the following to match the specific client environment settings\n",
+    "display.max_rows = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad3dd7b4-831c-4fb3-ab71-719c8c99a71c",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:1px;border:none;\">\n",
+    "<p style = 'font-size:18px;font-family:Arial'><b>1.1 Connect to Vantage</b></p>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>You will be prompted to provide the password. Enter your password, press the Enter key, and then use the down arrow to go to the next cell.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2742444c-4349-4b0f-b4e5-b068a8785cd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run -i ../../UseCases/startup.ipynb\n",
+    "eng = create_context(host = 'host.docker.internal', username='demo_user', password = password)\n",
+    "print(eng)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01c4a128-d106-46ea-8dee-34acc5abd29f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "execute_sql('''SET query_band='DEMO=PP_BreuschPaganGodfrey.ipynb;' UPDATE FOR SESSION; ''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efe2fd2d-63ff-4278-9157-8b9110d682e8",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:16px;font-family:Arial'>Begin running steps with Shift + Enter keys. </p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60882f80-eab2-489d-a0d2-5d12ab678b12",
+   "metadata": {},
+   "source": [
+    "<hr style='height:1px;border:none;background-color:#00233C;'>\n",
+    "\n",
+    "<p style = 'font-size:18px;font-family:Arial;color:#00233c'><b>1.2 Getting Data for This Demo</b></p>\n",
+    "\n",
+    "<p style = 'font-size:16px;font-family:Arial;color:#00233C'>Here, we will get the time series data which is available in the teradataml library and use the same to show the usage of the function.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ffb2350-1ebd-4109-88c6-72b33dfd750b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_example_data(\"uaf\", [\"house_values\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5716c9e-2ea9-480a-ab5d-5ce0c9e1ee07",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:2px;border:none;background-color:#00233C;\">\n",
+    "<b style = 'font-size:20px;font-family:Arial;color:#00233C'>2. Data Exploration</b>\n",
+    "<p style = 'font-size:16px;font-family:Arial;color:#00233C'>Create a \"Virtual DataFrame\" that points to the data set in Vantage. Check the shape of the dataframe as check the datatype of all the columns of the dataframe.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29e09b48-0662-441b-8c69-346559fbe788",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = DataFrame.from_table(\"house_values\")\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89fc6810-4e04-4924-8707-9c76b744f14f",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:2px;border:none;\">\n",
+    "<b style = 'font-size:20px;font-family:Arial'>3. BreuschPaganGodfrey</b>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>The BreuschPaganGodfrey() function checks for heteroscedasticity using one or more variables among the residual terms after running a regression.</p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69569645-5f0d-45d8-a446-da86217750e0",
+   "metadata": {},
+   "source": [
+    "<p></p>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>Detailed help can be found by passing function name to built-in help function. </p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cb9fedd-e3af-420a-b86f-17b2591e5603",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(BreuschPaganGodfrey)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26676d14-9d32-46f0-9b53-9992d3d76f49",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:16px;font-family:Arial'>We need to first convert the data from dataframe into a TDSeries which will be passed to the DickeyFuller function as input.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "516ee889-cd43-4d2b-aad8-a74a31f038b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_series_df = TDSeries(data=data,\n",
+    "                              id=\"cityid\",\n",
+    "                              row_index=\"TD_TIMECODE\",\n",
+    "                              payload_field=[\"house_val\",\"salary\",\"mortgage\"],\n",
+    "                              payload_content=\"MULTIVAR_REAL\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c33d0d74-f2b0-4d4a-be2c-dee1456427c4",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:16px;font-family:Arial'>We will create Multivariate regression model.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "261380ba-a48a-44bc-8429-94ce4e4f8a85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mvr_out = MultivarRegr(data=data_series_df,\n",
+    "                           variables_count=3,\n",
+    "                           weights=False,\n",
+    "                           formula=\"Y = B0 + B1*X1 + B2*X2\",\n",
+    "                           algorithm='QR',\n",
+    "                           coeff_stats=True,\n",
+    "                           model_stats=True,\n",
+    "                           residuals=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07d20b56-fca5-4266-9228-fa81be2907fa",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:16px;font-family:Arial;color:#00233C'>We will perform Breusch-Pagan-Godfrey (BPG) test using input as teradataml TDSeries object generated from model residuals.We will extract residuals from the model as TDSeries.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a33861b-db8b-44cd-90e6-173227500449",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_series_bg = TDSeries(data=mvr_out.fitresiduals,\n",
+    "                              id=\"cityid\",\n",
+    "                              row_index=\"ROW_I\",\n",
+    "                              row_index_style= \"SEQUENCE\",\n",
+    "                              payload_field=[\"RESIDUAL\",\"ACTUAL_VALUE\",\"CALC_VALUE\"],\n",
+    "                              payload_content=\"MULTIVAR_REAL\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da80f26b-2614-40ba-979b-d421952abc6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uaf_out = BreuschPaganGodfrey(data=data_series_bg,\n",
+    "                                  variables_count=2,\n",
+    "                                  significance_level=0.01)\n",
+    "\n",
+    "# Print the result DataFrame.\n",
+    "uaf_out.result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0320e5c-6fe2-4197-ac01-dafb9a9d6c45",
+   "metadata": {},
+   "source": [
+    "<p></p>\n",
+    "<p style = 'font-size:16px;font-family:Arial;color:#00233C'>The 'NULL_HYPOTHESIS' value determines if there is heteroscedasticity.</p> \n",
+    "          <li style = 'font-size:16px;font-family:Arial;color:#00233C'><b>ACCEPT</b> means that variance is homoscedastic.</li> \n",
+    "          <li style = 'font-size:16px;font-family:Arial;color:#00233C'><b>REJECT</b> means that variance is heteroscedastic.</li>\n",
+    "</p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46d3cf73-ecd6-4176-8d8c-c856f60407e3",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:2px;border:none;\">\n",
+    "<b style = 'font-size:20px;font-family:Arial'>4. Cleanup</b>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd35d15a-130a-4b48-9dac-e9a2fa8298cc",
+   "metadata": {},
+   "source": [
+    "<p style = 'font-size:18px;font-family:Arial'><b>Work Tables</b></p>\n",
+    "<p style = 'font-size:16px;font-family:Arial'>The following code will clean up intermediate tables.</p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6c28a7e-4f4d-4723-a909-d07c9fd1bb1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_drop_table(\"house_values\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07c01ccd-afd1-45ec-91ec-95ba0fb35312",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove_context()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4317a6cf-1479-4aa8-b30a-ee0a3b5231a8",
+   "metadata": {},
+   "source": [
+    "<hr style=\"height:1px;border:none;\">\n",
+    "\n",
+    "<p style = 'font-size:16px;font-family:Arial'><b>Links:</b></p>\n",
+    "<ul style = 'font-size:16px;font-family:Arial'>\n",
+    "    <li>Teradataml Python reference: <a href = 'https://docs.teradata.com/search/all?query=Python+Package+User+Guide&content-lang=en-US'>here</a></li>\n",
+    "    <li>BreuschPaganGodfrey function reference: <a href = 'https://docs.teradata.com/search/all?query=BreuschPaganGodfrey&content-lang=en-US'>here</a></li>\n",
+    "</ul>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2dcca28-5de5-44d7-88cb-45a12153b3f8",
+   "metadata": {},
+   "source": [
+    "<footer style=\"padding-bottom:35px; border-bottom:3px solid #91A0Ab\">\n",
+    "    <div style=\"float:left;margin-top:14px\">ClearScape Analytics™</div>\n",
+    "    <div style=\"float:right;\">\n",
+    "        <div style=\"float:left; margin-top:14px\">\n",
+    "            Copyright © Teradata Corporation - 2025. All Rights Reserved\n",
+    "        </div>\n",
+    "    </div>\n",
+    "</footer>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The BreuschPaganGodfrey() function is used to detect the presence of heteroscedasticity in regression analysis.  It checks for heteroscedasticity using one or more variables among the residual terms after running a regression.