### PR TITLE
fix/Complaints_Analysis_GenAI_Bedrock, added guidelines for topic modeling

### DIFF
--- a/UseCases/Complaints_Analysis_GenAI_Bedrock/Topic_Modelling.ipynb
+++ b/UseCases/Complaints_Analysis_GenAI_Bedrock/Topic_Modelling.ipynb
@@ -398,6 +398,7 @@
     "        - Only one sentence reasoning\n",
     "        Instructions for Topic:\n",
     "        - The complaint falls into only one of the following Topics: Mortgage Application, Payment Trouble, Mortgage Closing, Report Inaccuracy, Payment Struggle\n",
+    "        - Topics should not include commas\n",
     "        - Only select one Topic\n",
     "\n",
     "        My output comes in the format:\n",


### PR DESCRIPTION
Fixed the topic modeling demo of Complaints_Analysis_GenAI_Bedrock so the topics didn't duplicate with commas and without commas.
<img width="1119" height="347" alt="image" src="https://github.com/user-attachments/assets/4e7857a2-75dc-4598-b574-620e28b3e05f" />
<img width="1063" height="331" alt="image" src="https://github.com/user-attachments/assets/cef930b2-a3fe-4a27-aa71-ca4c5b631646" />
